### PR TITLE
Updated Upstream (Waterfall)

### DIFF
--- a/Waterfall-Proxy-Patches/0001-POM-Changes.patch
+++ b/Waterfall-Proxy-Patches/0001-POM-Changes.patch
@@ -1,11 +1,11 @@
-From 23f3ebb951403df84805e47c8e6509b54b52f549 Mon Sep 17 00:00:00 2001
+From 919f1ead07b7e2f9a82129b55373f88a278860e8 Mon Sep 17 00:00:00 2001
 From: Troy Frew <fuzzy_bot@arenaga.me>
 Date: Tue, 15 Nov 2016 08:56:43 -0500
 Subject: [PATCH] POM Changes
 
 
 diff --git a/api/pom.xml b/api/pom.xml
-index 2380a5fd..f95b96e0 100644
+index 705b7279..08395f48 100644
 --- a/api/pom.xml
 +++ b/api/pom.xml
 @@ -5,41 +5,41 @@
@@ -58,7 +58,7 @@ index 2380a5fd..f95b96e0 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/bootstrap/pom.xml b/bootstrap/pom.xml
-index e7b76d5b..8c9aba34 100644
+index 2876d8d6..6ac1da55 100644
 --- a/bootstrap/pom.xml
 +++ b/bootstrap/pom.xml
 @@ -5,18 +5,18 @@
@@ -84,7 +84,7 @@ index e7b76d5b..8c9aba34 100644
  
      <properties>
          <maven.deploy.skip>true</maven.deploy.skip>
-@@ -29,14 +29,14 @@
+@@ -30,14 +30,14 @@
      <dependencies>
          <dependency>
              <groupId>io.github.waterfallmc</groupId>
@@ -129,7 +129,7 @@ index 0bd76ea5..3cbe1abf 100644
      <dependencies>
          <dependency>
 diff --git a/config/pom.xml b/config/pom.xml
-index 764fcc6b..48184d59 100644
+index 4bf7237f..3e2b707b 100644
 --- a/config/pom.xml
 +++ b/config/pom.xml
 @@ -5,18 +5,18 @@
@@ -367,7 +367,7 @@ index d8ebf472..5c457f76 100644
      <packaging>jar</packaging>
  
 diff --git a/module/pom.xml b/module/pom.xml
-index 7b05190b..266678f4 100644
+index 261c8d75..b60e8ecc 100644
 --- a/module/pom.xml
 +++ b/module/pom.xml
 @@ -5,18 +5,18 @@
@@ -393,7 +393,7 @@ index 7b05190b..266678f4 100644
  
      <modules>
          <module>cmd-alert</module>
-@@ -35,7 +35,7 @@
+@@ -36,7 +36,7 @@
      <dependencies>
          <dependency>
              <groupId>io.github.waterfallmc</groupId>
@@ -450,7 +450,7 @@ index f8b549dc..b4459ace 100644
      <dependencies>
          <dependency>
 diff --git a/pom.xml b/pom.xml
-index 903fd182..508022b7 100644
+index 37bdaf3d..047bc3de 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -5,19 +5,19 @@
@@ -538,7 +538,7 @@ index 4592e2b3..0501a835 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index 52e45fe1..1c4b009f 100644
+index 54500dde..43c334db 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
 @@ -5,17 +5,17 @@
@@ -562,7 +562,7 @@ index 52e45fe1..1c4b009f 100644
      <description>Proxy component of the Elastic Portal Suite</description>
  
      <properties>
-@@ -41,14 +41,14 @@
+@@ -42,14 +42,14 @@
              <version>${netty.version}</version>
              <scope>compile</scope>
          </dependency>
@@ -579,7 +579,7 @@ index 52e45fe1..1c4b009f 100644
          <dependency>
              <groupId>io.netty</groupId>
              <artifactId>netty-handler</artifactId>
-@@ -64,31 +64,31 @@
+@@ -65,31 +65,31 @@
          </dependency>
          <dependency>
              <groupId>io.github.waterfallmc</groupId>


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Waterfall Changes:
e9ad343 Removed duplicated javadoc param (#456)
17d5b78 Updated Upstream (BungeeCord)